### PR TITLE
fix(ort-scan): Allow scanning a different revision of same repository

### DIFF
--- a/templates/ort-scan.yml
+++ b/templates/ort-scan.yml
@@ -88,10 +88,27 @@
       export POSTGRES_SCHEMA=${POSTGRES_SCHEMA-:$DB_SCHEMA}
       export POSTGRES_URL=${POSTGRES_URL-:$DB_URL}
       export POSTGRES_USERNAME=${POSTGRES_USERNAME-:$DB_USERNAME}
-      export PROJECT_PATH="${HOME}/project"
-      export PROJECT_VCS_REVISION=${VCS_REVISION:-"HEAD"}
-      export PROJECT_VCS_TYPE=${VCS_TYPE:-"git"}
-      export PROJECT_VCS_URL=${VCS_URL:-"ssh://git@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"}
+
+      if [ ! -n "${VCS_TYPE+x}" ] && \
+        [ ! -n "${VCS_URL+x}" ] && \
+        [ ! -n "${VCS_REVISION}" ] && \
+        [ ! -n "${VCS_PATH}" ]
+      then
+        # Scan already cloned repository under $CI_PROJECT_DIR:
+        export PROJECT_VCS_TYPE="git"
+        export PROJECT_VCS_URL="ssh://git@${CI_SERVER_HOST}/${CI_PROJECT_PATH}.git"
+        export PROJECT_VCS_REVISION="${CI_COMMIT_SHA}"
+        export PROJECT_VCS_PATH=""
+        export PROJECT_PATH="${CI_PROJECT_DIR}"
+      else
+        # Scan specified repository:
+        export PROJECT_VCS_TYPE=${VCS_TYPE:-"git"}
+        export PROJECT_VCS_URL=${VCS_URL:-""}
+        export PROJECT_VCS_REVISION=${VCS_REVISION:-""}
+        export PROJECT_VCS_PATH=${VCS_PATH:-""}
+        export PROJECT_PATH="${HOME}/project"
+      fi  
+
       export PROJECT_VCS_REPOSITORY_NAME=$(echo $PROJECT_VCS_URL | sed -E 's/.*\/(.*)\.git/\1/')
       export SW_NAME=${SW_NAME:-"$PROJECT_VCS_REPOSITORY_NAME"}
       # Remove all special characters and whitespace from software name as some tools cannot handle them.
@@ -230,15 +247,10 @@
 
     # Execute ORT's Downloader to fetch the source code for the project to be scanned.
     - |
-      if [[ ${PROJECT_VCS_URL} == *"${CI_PROJECT_PATH}"* ]]; then
-        export PROJECT_PATH="${CI_PROJECT_DIR}"
+      if [[ "$PROJECT_PATH" = "$CI_PROJECT_DIR" ]]
+      then
+        echo -e "\e[1;33m Not running ORT Downloader, as the already cloned sources are to be analyzed..."
       else
-        [[ -n "${PROJECT_VCS_TYPE}" ]] && ORT_CLI_DOWNLOAD_ARGS="--vcs-type ${PROJECT_VCS_TYPE} ${ORT_CLI_DOWNLOAD_ARGS}"
-        [[ -n "${PROJECT_VCS_URL}" ]] && ORT_CLI_DOWNLOAD_ARGS="--project-url ${PROJECT_VCS_URL} ${ORT_CLI_DOWNLOAD_ARGS}"
-        [[ -n "${PROJECT_VCS_REVISION}" ]] && ORT_CLI_DOWNLOAD_ARGS="--vcs-revision ${PROJECT_VCS_REVISION} ${ORT_CLI_DOWNLOAD_ARGS}"
-        [[ -n "${PROJECT_VCS_PATH}" ]] && ORT_CLI_DOWNLOAD_ARGS="--vcs-path ${PROJECT_VCS_PATH} ${ORT_CLI_DOWNLOAD_ARGS}"
-        [[ -n "${SW_NAME_SAFE}" ]] && ORT_CLI_DOWNLOAD_ARGS="--project-name ${SW_NAME_SAFE} ${ORT_CLI_DOWNLOAD_ARGS}"
-
         echo -e "\e[1;33m Running ORT Downloader to download project to scan... "
         echo -e "\e[1;33m ${PROJECT_VCS_TYPE} project revision ${PROJECT_VCS_REVISION} located at ${PROJECT_VCS_URL}... "
 
@@ -246,8 +258,11 @@
         --${ORT_LOG_LEVEL} \
         ${ORT_CLI_ARGS} \
         download \
-        -o ${PROJECT_PATH} \
-        ${ORT_CLI_DOWNLOAD_ARGS} \
+        -o "${PROJECT_PATH}" \
+        --vcs-type "$PROJECT_VCS_TYPE" \
+        --project-url "$PROJECT_VCS_URL" \
+        --vcs-revision "$PROJECT_VCS_REVISION" \
+        --project-name "$SW_NAME_SAFE" \
           || ORT_CLI_DOWNLOAD_EXIT_CODE=$? \
           && export ORT_CLI_DOWNLOAD_EXIT_CODE="${ORT_CLI_DOWNLOAD_EXIT_CODE:-0}"
         


### PR DESCRIPTION
The logic for determining whether the downloader needs to be run in
order to analyze a repository / revision different than the already
cloned one only considers the VCS_URL. This is not sufficient. In
particular, it is not possible to scan any other revision or branch of
that same repository.

Fix that problem by the following heuristic:

1. If the user did provided at least one `VCS_*` variable, then always
   use the downloader to obtain the sources to be analyzed.
2. Otherwise, analyze the already cloned repository.

Note: In case 2, the actual sha1 is now used as VCS_REVISION instead of
"HEAD".